### PR TITLE
Feature\View the latest branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 on: 
   push:
     branches:
-      - 'main'
+      - 'release/v2.2'
 
 jobs:
   archi_report:


### PR DESCRIPTION
Instead of displaying the main branch at https://nbility-model.github.io/NBility-business-capabilities-Archi/, we will now show the latest branch, which in this case is the release v2.2